### PR TITLE
ci: changes node version in build to 22.x and 24.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Node version 20 is already in maintenance mode, and v25 coming soon, so it makes sense to update the matrix for the latest versions 

<img width="960" height="500" alt="image" src="https://github.com/user-attachments/assets/cb66aaa2-0d31-4681-bfa8-d115747dfef2" />

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Which merge strategy will you use?
- [ ] Squash
- [x] Rebase (REVIEW COMMITS)